### PR TITLE
Add support for query string matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,8 +139,10 @@ function render(scenario) {
             prepareUriObj(call.request)
         ]).then(function (results) {
             return _.merge({}, item, {
-                request: { uri: results[2].uri, qs: results[2].qs, body: results[0] },
-                response: { body: results[1] }
+                value: {
+                    request: { uri: results[2].uri, qs: results[2].qs, body: results[0] },
+                    response: { body: results[1] }
+                }
             });
         });
     });

--- a/index.js
+++ b/index.js
@@ -198,8 +198,8 @@ class Vhttp {
             let eq = [
                 (method === callReq.method),
                 (uri === callReq.uri),
-                eql(opts.preparedBody, callReq.body),
-                eql(qs, callReq.qs)
+                eql(qs, callReq.qs),
+                eql(opts.preparedBody, callReq.body)
             ];
 
 
@@ -208,22 +208,23 @@ class Vhttp {
                 (callReq.qs ? ('?' + querystring.stringify(callReq.qs)) : '') +
                 ' - method:' + eq[0] +
                 '; uri:' + eq[1] +
-                '; body:' + eq[2] +
-                '; qs:' + eq[3]);
+                '; qs:' + eq[2] +
+                '; body:' + eq[3]);
+
             if (eq[0] && eq[1] && !eq[2]) {
-                _log.error(opts, {
-                    error: new Error(
-                        'Bodies do not match for ' + method + ':' + uri +
-                        '\nEXPECTED\n' + JSON.stringify(callReq.body, null, 4) +
-                        '\nACTUAL\n' + JSON.stringify(opts.preparedBody, null, 4))
-                });
-            }
-            if (eq[0] && eq[1] && !eq[3]) {
                 _log.error(opts, {
                     error: new Error(
                         'Query strings do not match for ' + method + ':' + uri +
                         '\nEXPECTED\n' + JSON.stringify(callReq.qs, null, 4) +
                         '\nACTUAL\n' + JSON.stringify(qs, null, 4))
+                });
+            }
+            if (eq[0] && eq[1] && !eq[3]) {
+                _log.error(opts, {
+                    error: new Error(
+                        'Bodies do not match for ' + method + ':' + uri +
+                        '\nEXPECTED\n' + JSON.stringify(callReq.body, null, 4) +
+                        '\nACTUAL\n' + JSON.stringify(opts.preparedBody, null, 4))
                 });
             }
 

--- a/index.js
+++ b/index.js
@@ -139,14 +139,8 @@ function render(scenario) {
             prepareUriObj(call.request)
         ]).then(function (results) {
             return _.merge({}, item, {
-                value: {
-                    request: { body: results[0] },
-                    response: { body: results[1] }
-                }
-            },{
-                value: {
-                    request: results[2]
-                }
+                request: { uri: results[2].uri, qs: results[2].qs, body: results[0] },
+                response: { body: results[1] }
             });
         });
     });

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ function prepareUriObj(opts){
         uriObj.uri = opts.uri.slice(0, queryIndex);
         return Promise.resolve(uriObj);
     } else {
-        return Promise.resolve(opts);
+        return Promise.resolve({uri: opts.uri, qs: opts.qs});
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vhttp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Promise based Node.js HTTP/HTTPS client with optional virtualization.",
   "main": "index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "lodash": "^4.13.1",
     "request-promise": "^3.0.0",
     "smart-eql": "^0.2.0",
-    "substituter": "^1.2.0",
+    "substituter": "^1.2.1",
     "xml2js": "^0.4.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vhttp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Promise based Node.js HTTP/HTTPS client with optional virtualization.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ before(function () {
     Vhttp.reset();
     Vhttp.configure({
         root: 'test/virtual',
-        quiet: true
+        quiet: false
     });
     Vhttp.register({
         scenario1: {


### PR DESCRIPTION
This PR adds support for query string matching. 

To support scenarios that contain query strings in the uri in addition to the qs option, the original uri passed in the scenario must be modified. All query strings are stripped from the uri and assigned to the query string object.