### PR TITLE
Add Node v6 support for querystring

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function prepareUriObj(opts) {
     if (queryIndex !== -1) {
         let uriQuery = querystring.parse(opts.uri.slice(queryIndex + 1));
         return Promise.resolve({
-            qs: opts.qs ? _.assign(opts.qs, uriQuery) : uriQuery,
+            qs: opts.qs ? _.assign(opts.qs, uriQuery) : _.assign({}, uriQuery),
             uri: opts.uri.slice(0, queryIndex)
         });
     } else {

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function prepareUriObj(opts) {
     if (queryIndex !== -1) {
         let uriQuery = querystring.parse(opts.uri.slice(queryIndex + 1));
         return Promise.resolve({
-            qs: opts.qs ? _.assign(opts.qs, uriQuery) : _.assign({}, uriQuery),
+            qs: _.assign({}, opts.qs, uriQuery),
             uri: opts.uri.slice(0, queryIndex)
         });
     } else {

--- a/test/index.js
+++ b/test/index.js
@@ -79,6 +79,15 @@ before(function () {
         scenario5: {
             'call1:1': {
                 method: 'get',
+                uri: 'http://test.url/path',
+                qs: {
+                    first: 'firstval'
+                }
+            }
+        },
+        scenario6: {
+            'call1:1': {
+                method: 'get',
                 uri: 'http://test.url/path2?first=firstval',
                 qs: {
                     second: 'secondval'
@@ -284,8 +293,31 @@ it('matches query strings', function () {
         });
 });
 
-it('combines uri and query strings passed as options', function () {
+it('matches result of parsing querystring with qs object', function () {
     return new Vhttp('scenario5')
+        .get('http://test.url/path?first=firstval')
+        .then(function (data) {
+            data.should.eql({
+                name: 'call1',
+                param: 'real-param'
+            });
+        });
+});
+
+it('can parse multiple query strings from url', function () {
+    return new Vhttp('scenario6')
+        .get('http://test.url/path2?second=secondval&first=firstval')
+        .then(function (data) {
+            data.should.eql({
+                name: 'call1',
+                param: 'real-param'
+            });
+        });
+});
+
+
+it('combines uri and query strings passed as options', function () {
+    return new Vhttp('scenario6')
         .get('http://test.url/path2?second=secondval', { qs: { first: 'firstval' } })
         .then(function (data) {
             data.should.eql({
@@ -296,13 +328,13 @@ it('combines uri and query strings passed as options', function () {
 });
 
 it('errs on missing query param', function () {
-    return new Vhttp('scenario5')
+    return new Vhttp('scenario6')
         .get('http://test.url/path2', { qs: { first: 'firstval' } })
         .then(function () {
             throw new Error('Error not thrown');
         })
         .catch(function (err) {
-            err.should.eql(new Error('No virtual scenario5 call found for GET:http://test.url/path2'));
+            err.should.eql(new Error('No virtual scenario6 call found for GET:http://test.url/path2'));
         });
 });
 


### PR DESCRIPTION
Changes to [Node.js v6 querystring.parse](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#querystring) caused the equality check of querystring objects to sometimes fail. 

* Added `_.assign` to empty `Object` so qs will always inherit from `Object.prototype` (rather than `Object.create(null)`) when making the comparison between real and virtualized scenarios. 
* Created 2 tests that explicitly check for cases where this bug would occur 